### PR TITLE
Remove SQLLight setup

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -34,10 +34,6 @@ jobs:
         uses: ryohidaka/action-setup-sqlite@v1.2.0
         with:
           version: 3.40.1
-      - name: setup database table
-        run: |
-          cd backend
-          sqlite3 todo.db "create table toDo (id uuid PRIMARY KEY, title TEXT, description TEXT, created_at DATETIME NOT NULL, updated_at DATETIME, deleted BIT default 0, done BIT default 0); create index title_index on toDo(title);"
       - name: Set up Python 3.13
         uses: actions/setup-python@v3
         with:


### PR DESCRIPTION
The db on disk is no longer needed. The tests now use an in-memory database.